### PR TITLE
Fix cart item id handling

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -860,9 +860,9 @@ function renderCart() {
           ${item.ingredients && item.ingredients.length ? `<div class="cart-item-extra">${item.ingredients.join(', ')}</div>` : ''}
           ${item.notes ? `<div class="cart-item-extra">Notes: ${item.notes}</div>` : ''}
           <div class="cart-item-controls">
-            <button class="qty-btn" onclick="decreaseQty('${item.id}')">−</button>
+            <button class="qty-btn" onclick="decreaseQty(${item.id})">−</button>
             <span class="cart-item-qty">${item.qty}</span>
-            <button class="qty-btn" onclick="increaseQty('${item.id}')">+</button>
+            <button class="qty-btn" onclick="increaseQty(${item.id})">+</button>
           </div>
         </div>
         <div class="cart-item-price">$${(item.price * item.qty).toFixed(2)}</div>

--- a/pos_webapp.html
+++ b/pos_webapp.html
@@ -860,9 +860,9 @@ function renderCart() {
           ${item.ingredients && item.ingredients.length ? `<div class="cart-item-extra">${item.ingredients.join(', ')}</div>` : ''}
           ${item.notes ? `<div class="cart-item-extra">Notes: ${item.notes}</div>` : ''}
           <div class="cart-item-controls">
-            <button class="qty-btn" onclick="decreaseQty('${item.id}')">−</button>
+            <button class="qty-btn" onclick="decreaseQty(${item.id})">−</button>
             <span class="cart-item-qty">${item.qty}</span>
-            <button class="qty-btn" onclick="increaseQty('${item.id}')">+</button>
+            <button class="qty-btn" onclick="increaseQty(${item.id})">+</button>
           </div>
         </div>
         <div class="cart-item-price">$${(item.price * item.qty).toFixed(2)}</div>


### PR DESCRIPTION
## Summary
- keep numeric IDs when creating cart items
- pass numeric ID to `increaseQty` and `decreaseQty`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685cd8c558c0833180e4166862944b11