### PR TITLE
Fix cart qty button events

### DIFF
--- a/pos_webapp.html
+++ b/pos_webapp.html
@@ -748,6 +748,19 @@ cartToggle?.addEventListener('click', () => {
   cartEl.classList.toggle('hidden');
 });
 
+// Handle quantity button clicks
+cartItemsEl.addEventListener('click', (e) => {
+  const btn = e.target.closest('.qty-btn');
+  if (!btn) return;
+  const action = btn.dataset.action;
+  const id = Number(btn.dataset.id);
+  if (action === 'inc') {
+    increaseQty(id);
+  } else if (action === 'dec') {
+    decreaseQty(id);
+  }
+});
+
 // Ingredient customization modal elements
 const overlay = document.getElementById('ingredient-overlay');
 const modal = document.getElementById('ingredient-modal');
@@ -919,9 +932,9 @@ function renderCart() {
           <div class="cart-item-name">${item.name}</div>
           ${item.ingredients && item.ingredients.length ? `<div class="cart-item-extra">${item.ingredients.join(', ')}</div>` : ''}
           <div class="cart-item-controls">
-            <button class="qty-btn" onclick="decreaseQty(${item.id})">−</button>
+            <button class="qty-btn" data-action="dec" data-id="${item.id}">−</button>
             <span class="cart-item-qty">${item.qty}</span>
-            <button class="qty-btn" onclick="increaseQty(${item.id})">+</button>
+            <button class="qty-btn" data-action="inc" data-id="${item.id}">+</button>
           </div>
         </div>
         <div class="cart-item-price">$${(item.price * item.qty).toFixed(2)}</div>


### PR DESCRIPTION
## Summary
- delegate cart quantity button clicks from cartItemsEl
- use data attributes instead of inline onclick for qty buttons

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d9c5dbd888331826652487b9282e5